### PR TITLE
Add additional rules;

### DIFF
--- a/base.json
+++ b/base.json
@@ -1,10 +1,13 @@
 {
   "extends": "eslint:recommended",
   "rules": {
+    "comma-spacing": "error",
+    "curly": ["error", "multi", "consistent"],
+    "dot-notation": "error",
     "eol-last": "error",
     "eqeqeq": "error",
     "guard-for-in": "error",
-    "indent": ["error", "tab"],
+    "indent": ["error", "tab", { "SwitchCase": 1 }],
     "no-eval": "error",
     "no-implied-eval": "error",
     "no-restricted-globals": ["error", "fdescribe", "fit"],


### PR DESCRIPTION
Add the following after observing some of our rule overrides and conventions:

- `comma-spacing` - Space after commas.
- `curly` - Omit curlies if an `if`/`else` has one statement, but require the use of curlies to be consistent in an `if`/`else` block.
- `dot-notation` - Prefers `obj.a` over `obj['a']`.
- `indent` - Indent case labels in switch statements.